### PR TITLE
Optional charset for email subject

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ organization := "me.lessis"
 
 name := "courier"
 
-version := "0.1.3"
+version := "0.1.4-SNAPSHOT"
 
 description := "deliver electronic mail with scala"
 

--- a/src/main/scala/envelope.scala
+++ b/src/main/scala/envelope.scala
@@ -1,5 +1,6 @@
 package courier
 
+import java.nio.charset.Charset
 import javax.mail.internet.InternetAddress
 
 object Envelope {
@@ -9,7 +10,7 @@ object Envelope {
 
 case class Envelope(
   from: InternetAddress,
-  _subject: Option[String] = None,
+  _subject: Option[(String, Charset)] = None,
   _to: Seq[InternetAddress] = Seq.empty[InternetAddress],
   _cc: Seq[InternetAddress] = Seq.empty[InternetAddress],
   _bcc: Seq[InternetAddress] = Seq.empty[InternetAddress],
@@ -18,7 +19,8 @@ case class Envelope(
   _headers: Seq[(String, String)] = Seq.empty[(String, String)],
   _content: Content = Text("")) {
 
-  def subject(s: String) = copy(_subject = Some(s))
+  def subject(s: String) = copy(_subject = Some(s, Charset.defaultCharset()))
+  def subject(s: String, ch: Charset) = copy(_subject = Some(s, ch))
   def to(addrs: InternetAddress*) = copy(_to = _to ++ addrs)
   def cc(addrs: InternetAddress*) = copy(_cc = _cc ++ addrs)
   def bcc(addrs: InternetAddress*) = copy(_bcc = _bcc ++ addrs)

--- a/src/main/scala/mailer.scala
+++ b/src/main/scala/mailer.scala
@@ -15,7 +15,7 @@ case class Mailer(
 
   def apply(e: Envelope)(implicit ec: ExecutionContext): Future[Unit] = {
     val msg = new MimeMessage(_session) {
-      e.subject.map(setSubject(_))
+      e.subject.foreach(t => setSubject(t._1, t._2.name()))
       setFrom(e.from)
       e.to.foreach(addRecipient(Message.RecipientType.TO, _))
       e.cc.foreach(addRecipient(Message.RecipientType.CC, _))


### PR DESCRIPTION
Hi @softprops,
please accept the following pull request to enable optional setting of email subject character set. Otherwise, default charset is used which prevents proper subject display if non-English language is used.

thanks in advance,
-tomas
