### PR TITLE
Converted From Function To Implicit Class

### DIFF
--- a/src/main/scala/package.scala
+++ b/src/main/scala/package.scala
@@ -3,12 +3,9 @@ import javax.mail.internet.InternetAddress
 /** An agreeable email interface for scala. */
 package object courier {
 
-  // change to implicit class when dropping 2.9.3
-  implicit def addr(name: String) =/*extends AnyVal*/ new {
-    def `@`(host: String) = new InternetAddress("%s@%s" format(name, host))
-    
+  implicit class addr(name: String){
+    def `@`(domain: String): InternetAddress = new InternetAddress(s"$name@$domain")
     def at = `@` _
-
     /** In case whole string is email address already */
     def addr = new InternetAddress(name)
   }


### PR DESCRIPTION
Implicit Class Resolution Works With Newer Scala Versions as the previous method no longer served to implicitly convert in 2.11.8. 
