### PR TITLE
Fix broken URL to Mock JavaMail in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,6 @@ class MailSpec extends Specification with NoTimeConversions {
 }        
 ```
 
-[Here](https://weblogs.java.net/blog/2007/04/26/introducing-mock-javamail-project) is an excellent article on using Mock JavaMail.
+[Here](https://community.oracle.com/blogs/kohsuke/2007/04/26/introducing-mock-javamail-project) is an excellent article on using Mock JavaMail.
 
 Doug Tangren (softprops) 2013


### PR DESCRIPTION
Current URL in README redirects to http://www.oracle.com/splash/java.net/maintenance/index.html and shows:

<img width="463" alt="screen shot 2017-08-15 at 01 41 08" src="https://user-images.githubusercontent.com/113730/29303436-d6204694-815a-11e7-9e49-fe19aa65e7ba.png">
